### PR TITLE
Fix test cases

### DIFF
--- a/5_4.go
+++ b/5_4.go
@@ -33,7 +33,7 @@ func TestConnectionErrorHandling(ctx *Context) {
 			case f := <-http2Conn.dataCh:
 				gf, ok := f.(*http2.GoAwayFrame)
 				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
+					if gf.ErrCode == http2.ErrCodeStreamClosed {
 						gfResult = true
 					}
 				}

--- a/6_10.go
+++ b/6_10.go
@@ -333,7 +333,7 @@ func TestContinuation(ctx *Context) {
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
-		hp.EndStream = true
+		hp.EndStream = false
 		hp.EndHeaders = true
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)

--- a/6_9.go
+++ b/6_9.go
@@ -46,7 +46,7 @@ func TestWindowUpdate(ctx *Context) {
 
 	func(ctx *Context) {
 		desc := "Sends a WINDOW_UPDATE frame with an flow control window increment of 0 on a stream"
-		msg := "the endpoint MUST respond with a connection error of type PROTOCOL_ERROR."
+		msg := "the endpoint MUST respond with a stream error of type PROTOCOL_ERROR."
 		result := false
 
 		http2Conn := CreateHttp2Conn(ctx, true)
@@ -78,7 +78,7 @@ func TestWindowUpdate(ctx *Context) {
 		for {
 			select {
 			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
+				gf, ok := f.(*http2.RSTStreamFrame)
 				if ok {
 					if gf.ErrCode == http2.ErrCodeProtocol {
 						result = true


### PR DESCRIPTION
5.4: We submitted DATA to non-open stream, thus we expect
STREAM_CLOSED error code.

6_10: We should not set END_STREAM flag to HEADERS, otherwise
following DATA is treated as stream error (STREAM_CLOSED) because
half-closed (remote) and no GOAWAY situation arises.

6_9: From the specification, WINDOW_UPDATE with increment of 0 to a
stream causes stream error, not connection error.  Although,
implementation may choose connection error at their will.