### PR TITLE
Support TLS

### DIFF
--- a/cmd/h2spec.go
+++ b/cmd/h2spec.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"github.com/summerwind/h2spec"
@@ -10,14 +11,15 @@ import (
 func main() {
 	port := flag.Int("p", 80, "Target port")
 	host := flag.String("h", "127.0.0.1", "Target host")
-	tls := flag.Bool("tls", false, "Use TLS")
-
+	useTls := flag.Bool("t", false, "Connect over TLS")
+	insecureSkipVerify := flag.Bool("k", false, "Don't verify server's certificate")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS]\n\n", os.Args[0])
 		fmt.Println("Options:")
 		fmt.Println("  -p:     Target port. (Default: 80)")
 		fmt.Println("  -h:     Target host. (Default: 127.0.0.1)")
-		fmt.Println("  --tls:  Use TLS. (Default: false)")
+		fmt.Println("  -t:     Connect over TLS. (Default: false)")
+		fmt.Println("  -k:     Don't verify server's certificate. (Default: false)")
 		fmt.Println("  --help: Display this help and exit.")
 		os.Exit(1)
 	}
@@ -27,7 +29,10 @@ func main() {
 	var ctx h2spec.Context
 	ctx.Port = *port
 	ctx.Host = *host
-	ctx.UseTLS = *tls
+	ctx.Tls = *useTls
+	ctx.TlsConfig = &tls.Config{
+		InsecureSkipVerify: *insecureSkipVerify,
+	}
 
 	h2spec.Run(&ctx)
 }


### PR DESCRIPTION
This change add TLS support.  2 command-line flags were added: -t and
-k.  -t indicates TLS use.  -k indicates skipping verification of
server's certificates.  Currently h2-14 and h2-16 are hard coded to
NPN tokens.