### PR TITLE
Add error checks for type casts in 4.2

### DIFF
--- a/4_2.go
+++ b/4_2.go
@@ -24,7 +24,7 @@ func TestFrameSize(ctx *Context) {
 		for {
 			select {
 			case f := <-http2Conn.dataCh:
-				gf := f.(*http2.GoAwayFrame)
+				gf,_ := f.(*http2.GoAwayFrame)
 				if gf != nil {
 					if gf.ErrCode == http2.ErrCodeFrameSize {
 						result = true
@@ -56,7 +56,7 @@ func TestFrameSize(ctx *Context) {
 		for {
 			select {
 			case f := <-http2Conn.dataCh:
-				gf := f.(*http2.GoAwayFrame)
+				gf,_ := f.(*http2.GoAwayFrame)
 				if gf != nil {
 					if gf.ErrCode == http2.ErrCodeFrameSize {
 						result = true

--- a/5_4.go
+++ b/5_4.go
@@ -33,7 +33,7 @@ func TestConnectionErrorHandling(ctx *Context) {
 			case f := <-http2Conn.dataCh:
 				gf, ok := f.(*http2.GoAwayFrame)
 				if ok {
-					if gf.ErrCode == http2.ErrCodeStreamClosed {
+					if gf.ErrCode == http2.ErrCodeProtocol {
 						gfResult = true
 					}
 				}

--- a/6_7.go
+++ b/6_7.go
@@ -85,7 +85,7 @@ func TestPing(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		fmt.Fprintf(http2Conn.conn, "\x00\x00\x06\x06\x00\x00\x00\x00\x03")
+		fmt.Fprintf(http2Conn.conn, "\x00\x00\x06\x06\x00\x00\x00\x00\x00")
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x00\x00\x00\x00")
 
 		timeCh := time.After(3 * time.Second)


### PR DESCRIPTION
This PR fixes a few panics that occur in the failure case when casts are not checked.
