### PR TITLE
5.4.1: Expect STREAM_CLOSED since we send DATA to idle stream

### DIFF
--- a/5_4.go
+++ b/5_4.go
@@ -33,7 +33,7 @@ func TestConnectionErrorHandling(ctx *Context) {
 			case f := <-http2Conn.dataCh:
 				gf, ok := f.(*http2.GoAwayFrame)
 				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
+					if gf.ErrCode == http2.ErrCodeStreamClosed {
 						gfResult = true
 					}
 				}


### PR DESCRIPTION
This may be a bit fragile but we are sending DATA to idle stream (i.e., not "open" state), which means we should expect STREAM_CLOSED error code.