### PR TITLE
Refactor reading frame

### DIFF
--- a/4_2.go
+++ b/4_2.go
@@ -18,24 +18,19 @@ func TestFrameSize(ctx *Context) {
 		defer http2Conn.conn.Close()
 
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x00\x08\x00\x00\x00\x00\x00")
-		timeCh := time.After(3 * time.Second)
 
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf,_ := f.(*http2.GoAwayFrame)
-				if gf != nil {
-					if gf.ErrCode == http2.ErrCodeFrameSize {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeFrameSize {
+					result = true
+					break loop
 				}
-				break
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -50,24 +45,19 @@ func TestFrameSize(ctx *Context) {
 		defer http2Conn.conn.Close()
 
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x0f\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-		timeCh := time.After(3 * time.Second)
 
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf,_ := f.(*http2.GoAwayFrame)
-				if gf != nil {
-					if gf.ErrCode == http2.ErrCodeFrameSize {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeFrameSize {
+					result = true
+					break loop
 				}
-				break
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/4_3.go
+++ b/4_3.go
@@ -18,22 +18,18 @@ func TestHeaderCompressionAndDecompression(ctx *Context) {
 		defer http2Conn.conn.Close()
 
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x14\x01\x05\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-		timeCh := time.After(3 * time.Second)
 
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch frame := f.(type) {
-				case *http2.GoAwayFrame:
-					if frame.ErrCode == http2.ErrCodeCompression {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f:= f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeCompression {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/5_1.go
+++ b/5_1.go
@@ -43,22 +43,17 @@ func TestStreamIdentifiers(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -98,22 +93,17 @@ func TestStreamIdentifiers(ctx *Context) {
 		hp2.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp2)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/5_4.go
+++ b/5_4.go
@@ -29,25 +29,20 @@ func TestConnectionErrorHandling(ctx *Context) {
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x08\x06\x00\x00\x00\x00\x03")
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x00\x00\x00\x00\x00\x00")
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						gfResult = true
-					}
-				}
-			case err := <-http2Conn.errCh:
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
 				if err == io.EOF {
 					closeResult = true
 				}
 				break loop
-			case <-timeCh:
-				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					gfResult = true
+				}
 			}
 		}
 

--- a/6_1.go
+++ b/6_1.go
@@ -19,22 +19,18 @@ func TestData(ctx *Context) {
 		defer http2Conn.conn.Close()
 
 		http2Conn.fr.WriteData(0, true, []byte("test"))
-		timeCh := time.After(3 * time.Second)
 
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -69,22 +65,17 @@ func TestData(ctx *Context) {
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeStreamClosed {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeStreamClosed {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/6_10.go
+++ b/6_10.go
@@ -51,20 +51,15 @@ func TestContinuation(ctx *Context) {
 
 		http2Conn.fr.WriteContinuation(1, true, blockFragment[16384:])
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				_, ok := f.(*http2.HeadersFrame)
-				if ok {
-					result = true
-					break loop
-				}
-			case <-http2Conn.errCh:
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
 				break loop
-			case <-timeCh:
+			}
+			switch f.(type) {
+			case *http2.HeadersFrame:
+				result = true
 				break loop
 			}
 		}
@@ -109,20 +104,15 @@ func TestContinuation(ctx *Context) {
 		http2Conn.fr.WriteContinuation(1, false, blockFragment[16384:32767])
 		http2Conn.fr.WriteContinuation(1, true, blockFragment[32767:])
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				_, ok := f.(*http2.HeadersFrame)
-				if ok {
-					result = true
-					break loop
-				}
-			case <-http2Conn.errCh:
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
 				break loop
-			case <-timeCh:
+			}
+			switch f.(type) {
+			case *http2.HeadersFrame:
+				result = true
 				break loop
 			}
 		}
@@ -168,23 +158,18 @@ func TestContinuation(ctx *Context) {
 
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -228,23 +213,18 @@ func TestContinuation(ctx *Context) {
 		http2Conn.fr.WriteContinuation(1, false, blockFragment[16384:32767])
 		http2Conn.fr.WriteContinuation(3, true, blockFragment[32767:])
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -288,23 +268,18 @@ func TestContinuation(ctx *Context) {
 		http2Conn.fr.WriteContinuation(1, false, blockFragment[16384:32767])
 		http2Conn.fr.WriteContinuation(0, true, blockFragment[32767:])
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -342,23 +317,18 @@ func TestContinuation(ctx *Context) {
 
 		http2Conn.fr.WriteContinuation(1, true, buf.Bytes())
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/6_2.go
+++ b/6_2.go
@@ -39,22 +39,17 @@ func TestHeaders(ctx *Context) {
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -95,22 +90,17 @@ func TestHeaders(ctx *Context) {
 		hp2.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp2)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -144,22 +134,17 @@ func TestHeaders(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -190,22 +175,17 @@ func TestHeaders(ctx *Context) {
 		http2Conn.conn.Write(buf.Bytes())
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/6_4.go
+++ b/6_4.go
@@ -18,22 +18,17 @@ func TestRstStream(ctx *Context) {
 
 		http2Conn.fr.WriteRSTStream(0, http2.ErrCodeCancel)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -50,22 +45,17 @@ func TestRstStream(ctx *Context) {
 
 		http2Conn.fr.WriteRSTStream(1, http2.ErrCodeCancel)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/6_7.go
+++ b/6_7.go
@@ -20,23 +20,18 @@ func TestPing(ctx *Context) {
 		data := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
 		http2Conn.fr.WritePing(false, data)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				pf, ok := f.(*http2.PingFrame)
-				if ok {
-					if pf.FrameHeader.Flags.Has(http2.FlagPingAck) {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.PingFrame:
+				if f.FrameHeader.Flags.Has(http2.FlagPingAck) {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -54,23 +49,18 @@ func TestPing(ctx *Context) {
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x08\x06\x00\x00\x00\x00\x03")
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x00\x00\x00\x00\x00\x00")
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 
@@ -88,23 +78,18 @@ func TestPing(ctx *Context) {
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x06\x06\x00\x00\x00\x00\x00")
 		fmt.Fprintf(http2Conn.conn, "\x00\x00\x00\x00\x00\x00")
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeFrameSize {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeFrameSize {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
 			}
 		}
 

--- a/8_1.go
+++ b/8_1.go
@@ -46,28 +46,23 @@ func TestHTTPHeaderFields(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 
@@ -111,28 +106,23 @@ func TestPseudoHeaderFields(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 
@@ -167,28 +157,23 @@ func TestPseudoHeaderFields(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 
@@ -223,28 +208,23 @@ func TestPseudoHeaderFields(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 
@@ -286,28 +266,23 @@ func TestConnectionSpecificHeaderFields(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 
@@ -343,28 +318,23 @@ func TestConnectionSpecificHeaderFields(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 
@@ -401,28 +371,23 @@ func TestRequestPseudoHeaderFields(ctx *Context) {
 		hp.BlockFragment = buf.Bytes()
 		http2Conn.fr.WriteHeaders(hp)
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 
@@ -464,28 +429,23 @@ func TestMalformedRequestsAndResponses(ctx *Context) {
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 
-		timeCh := time.After(3 * time.Second)
-
 	loop:
 		for {
-			select {
-			case f := <-http2Conn.dataCh:
-				switch f := f.(type) {
-				case *http2.RSTStreamFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
-				case *http2.GoAwayFrame:
-					if f.ErrCode == http2.ErrCodeProtocol {
-						result = true
-						break loop
-					}
+			f, err := http2Conn.ReadFrame(3 * time.Second)
+			if err != nil {
+				break loop
+			}
+			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
 				}
-			case <-http2Conn.errCh:
-				break loop
-			case <-timeCh:
-				break loop
+			case *http2.GoAwayFrame:
+				if f.ErrCode == http2.ErrCodeProtocol {
+					result = true
+					break loop
+				}
 			}
 		}
 


### PR DESCRIPTION
Previously we call fr.ReadFrame() in go routine, but it is potentially
dangerous since fr.ReadFrame() doc says that the returned http2.Frame
"is only valid until the next call to ReadFrame."

This commit avoids the above problem by reading frame at a time and
process it completely before calling fr.ReadFrame().