### PR TITLE
6.1 should check against RST_STREAM

### DIFF
--- a/6_1.go
+++ b/6_1.go
@@ -75,9 +75,13 @@ func TestData(ctx *Context) {
 		for {
 			select {
 			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.RSTStreamFrame)
-				if ok {
-					if gf.ErrCode == http2.ErrCodeStreamClosed {
+				switch f := f.(type) {
+				case *http2.RSTStreamFrame:
+					if f.ErrCode == http2.ErrCodeStreamClosed {
+						result = true
+					}
+				case *http2.GoAwayFrame:
+					if f.ErrCode == http2.ErrCodeStreamClosed {
 						result = true
 					}
 				}

--- a/6_1.go
+++ b/6_1.go
@@ -75,7 +75,7 @@ func TestData(ctx *Context) {
 		for {
 			select {
 			case f := <-http2Conn.dataCh:
-				gf, ok := f.(*http2.GoAwayFrame)
+				gf, ok := f.(*http2.RSTStreamFrame)
 				if ok {
 					if gf.ErrCode == http2.ErrCodeStreamClosed {
 						result = true


### PR DESCRIPTION
Draft-16 6.1 says:
>  If a DATA frame is received whose stream is not in "open" or "half closed (local)" state, the recipient MUST respond with a stream error (Section 5.4.2) of type STREAM_CLOSED. 

The test correctly prints as such, but the implementation was expecting GOAWAY instead.