### PR TITLE
Refactor encoding header to make writing test easy

### DIFF
--- a/4_2.go
+++ b/4_2.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
 )
@@ -23,23 +22,18 @@ func TestFrameSize(ctx *Context) {
 
 		http2Conn.fr.WriteSettings()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteData(1, true, []byte(GetDummyData(16385)))
 

--- a/5_1.go
+++ b/5_1.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
 )
@@ -27,23 +26,18 @@ func TestStreamIdentifiers(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 2
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -70,30 +64,25 @@ func TestStreamIdentifiers(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp1 http2.HeadersFrameParam
 		hp1.StreamID = 5
 		hp1.EndStream = true
 		hp1.EndHeaders = true
-		hp1.BlockFragment = buf.Bytes()
+		hp1.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp1)
 
 		var hp2 http2.HeadersFrameParam
 		hp2.StreamID = 3
 		hp2.EndStream = true
 		hp2.EndHeaders = true
-		hp2.BlockFragment = buf.Bytes()
+		hp2.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp2)
 
 	loop:

--- a/6_1.go
+++ b/6_1.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
 )
@@ -48,23 +47,18 @@ func TestData(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 

--- a/6_10.go
+++ b/6_10.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
 )
@@ -29,7 +28,6 @@ func TestContinuation(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -38,12 +36,8 @@ func TestContinuation(ctx *Context) {
 			pair("x-dummy1", GetDummyData(10000)),
 			pair("x-dummy2", GetDummyData(10000)),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
-		var blockFragment = buf.Bytes()
+		blockFragment := http2Conn.EncodeHeader(hdrs)
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
@@ -78,7 +72,6 @@ func TestContinuation(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -90,12 +83,8 @@ func TestContinuation(ctx *Context) {
 			pair("x-dummy4", GetDummyData(10000)),
 			pair("x-dummy5", GetDummyData(10000)),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
-		var blockFragment = buf.Bytes()
+		blockFragment := http2Conn.EncodeHeader(hdrs)
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
@@ -131,7 +120,6 @@ func TestContinuation(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -143,12 +131,8 @@ func TestContinuation(ctx *Context) {
 			pair("x-dummy4", GetDummyData(10000)),
 			pair("x-dummy5", GetDummyData(10000)),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
-		var blockFragment = buf.Bytes()
+		blockFragment := http2Conn.EncodeHeader(hdrs)
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
@@ -187,7 +171,6 @@ func TestContinuation(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -199,12 +182,8 @@ func TestContinuation(ctx *Context) {
 			pair("x-dummy4", GetDummyData(10000)),
 			pair("x-dummy5", GetDummyData(10000)),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
-		var blockFragment = buf.Bytes()
+		blockFragment := http2Conn.EncodeHeader(hdrs)
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
@@ -242,7 +221,6 @@ func TestContinuation(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -254,12 +232,8 @@ func TestContinuation(ctx *Context) {
 			pair("x-dummy4", GetDummyData(10000)),
 			pair("x-dummy5", GetDummyData(10000)),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
-		var blockFragment = buf.Bytes()
+		blockFragment := http2Conn.EncodeHeader(hdrs)
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
@@ -297,28 +271,23 @@ func TestContinuation(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 
-		http2Conn.fr.WriteContinuation(1, true, buf.Bytes())
+		http2Conn.fr.WriteContinuation(1, true, http2Conn.EncodeHeader(hdrs))
 
 	loop:
 		for {

--- a/6_2.go
+++ b/6_2.go
@@ -22,23 +22,18 @@ func TestHeaders(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = false
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 
@@ -67,30 +62,25 @@ func TestHeaders(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp1 http2.HeadersFrameParam
 		hp1.StreamID = 1
 		hp1.EndStream = false
 		hp1.EndHeaders = false
-		hp1.BlockFragment = buf.Bytes()
+		hp1.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp1)
 
 		var hp2 http2.HeadersFrameParam
 		hp2.StreamID = 3
 		hp2.EndStream = true
 		hp2.EndHeaders = true
-		hp2.BlockFragment = buf.Bytes()
+		hp2.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp2)
 
 	loop:
@@ -118,23 +108,18 @@ func TestHeaders(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 0
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:

--- a/6_3.go
+++ b/6_3.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
@@ -22,23 +21,18 @@ func TestPriority(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 		// PRIORITY Frame
@@ -70,23 +64,18 @@ func TestPriority(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 		// PRIORITY Frame

--- a/6_4.go
+++ b/6_4.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
@@ -76,23 +75,18 @@ func TestRstStream(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 		// RST_STREAM Frame

--- a/6_9.go
+++ b/6_9.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
@@ -50,23 +49,18 @@ func TestWindowUpdate(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteWindowUpdate(1, 0)
 

--- a/8_1.go
+++ b/8_1.go
@@ -1,7 +1,6 @@
 package h2spec
 
 import (
-	"bytes"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
 )
@@ -27,7 +26,6 @@ func TestHTTPHeaderFields(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -35,16 +33,12 @@ func TestHTTPHeaderFields(ctx *Context) {
 			pair(":authority", ctx.Authority()),
 			pair("X-TEST", "test"),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -87,7 +81,6 @@ func TestPseudoHeaderFields(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -95,16 +88,12 @@ func TestPseudoHeaderFields(ctx *Context) {
 			pair(":authority", ctx.Authority()),
 			pair(":status", "200"),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -138,7 +127,6 @@ func TestPseudoHeaderFields(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -146,16 +134,12 @@ func TestPseudoHeaderFields(ctx *Context) {
 			pair(":authority", ctx.Authority()),
 			pair(":test", "test"),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -189,7 +173,6 @@ func TestPseudoHeaderFields(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair("x-test", "test"),
 			pair(":method", "GET"),
@@ -197,16 +180,12 @@ func TestPseudoHeaderFields(ctx *Context) {
 			pair(":path", "/"),
 			pair(":authority", ctx.Authority()),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -244,7 +223,6 @@ func TestConnectionSpecificHeaderFields(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -252,16 +230,12 @@ func TestConnectionSpecificHeaderFields(ctx *Context) {
 			pair(":authority", ctx.Authority()),
 			pair("connection", "keep-alive"),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -295,7 +269,6 @@ func TestConnectionSpecificHeaderFields(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
@@ -304,16 +277,12 @@ func TestConnectionSpecificHeaderFields(ctx *Context) {
 			pair("trailers", "test"),
 			pair("te", "trailers, deflate"),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -351,22 +320,17 @@ func TestRequestPseudoHeaderFields(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "GET"),
 			pair(":scheme", "http"),
 			pair(":authority", ctx.Authority()),
-		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
 		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = true
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 
 	loop:
@@ -404,7 +368,6 @@ func TestMalformedRequestsAndResponses(ctx *Context) {
 		http2Conn := CreateHttp2Conn(ctx, true)
 		defer http2Conn.conn.Close()
 
-		var buf bytes.Buffer
 		hdrs := []hpack.HeaderField{
 			pair(":method", "POST"),
 			pair(":scheme", "http"),
@@ -412,16 +375,12 @@ func TestMalformedRequestsAndResponses(ctx *Context) {
 			pair(":authority", ctx.Authority()),
 			pair("content-length", "1"),
 		}
-		enc := hpack.NewEncoder(&buf)
-		for _, hf := range hdrs {
-			_ = enc.WriteField(hf)
-		}
 
 		var hp http2.HeadersFrameParam
 		hp.StreamID = 1
 		hp.EndStream = false
 		hp.EndHeaders = true
-		hp.BlockFragment = buf.Bytes()
+		hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 		http2Conn.fr.WriteHeaders(hp)
 		http2Conn.fr.WriteData(1, true, []byte("test"))
 


### PR DESCRIPTION
Previously HPACK encoder is defined in each test case and we do encoding all headers with loop every time.
With this commit, Http2Conn gets HPACK encoder and its EncodeHeader function encodes given header fields and returns byte string.