### PR TITLE
Fix 5.1.2 test

### DIFF
--- a/5_1.go
+++ b/5_1.go
@@ -141,6 +141,11 @@ func TestStreamConcurrency(ctx *Context) {
 				break loop
 			}
 			switch f := f.(type) {
+			case *http2.RSTStreamFrame:
+				if f.ErrCode == http2.ErrCodeProtocol || f.ErrCode == http2.ErrCodeRefusedStream {
+					result = true
+					break loop
+				}
 			case *http2.GoAwayFrame:
 				if f.ErrCode == http2.ErrCodeProtocol || f.ErrCode == http2.ErrCodeRefusedStream {
 					result = true


### PR DESCRIPTION
HTTP/2 implementations can raise errors as stream or connection level
errors when breaching HEADERS concurrency limits:

5.1.2 (-draft16)
"An endpoint that receives a HEADERS frame that causes their advertised
concurrent stream limit to be exceeded MUST treat this as a stream error
(Section 5.4.2) of type PROTOCOL_ERROR or REFUSED_STREAM."

5.4.1 (-draft16)
"In particular, an endpoint MAY choose to treat a stream error as a
connection error."

Therefore _both_ are valid.