### PR TITLE
unset the END_HEADERS flag for stream concurrency test

### DIFF
--- a/5_1.go
+++ b/5_1.go
@@ -109,7 +109,7 @@ func StreamConcurrencyTestGroup() *TestGroup {
 				var hp http2.HeadersFrameParam
 				hp.StreamID = streamID
 				hp.EndStream = true
-				hp.EndHeaders = true
+				hp.EndHeaders = false
 				hp.BlockFragment = hbf
 				http2Conn.fr.WriteHeaders(hp)
 				streamID += 2


### PR DESCRIPTION
Since HTTP/2 runs on a bi-directional stream, servers are allowed to send responses (and close the streams) as they receive the requests.

This PR drops the `END_HEADERS` flag used for the stream concurrency test so that it would not report false positives when used against such server implementations.