### PR TITLE
Fix test 4.2 to test for stream error

### DIFF
--- a/4_2.go
+++ b/4_2.go
@@ -33,7 +33,7 @@ func FrameSizeTestGroup() *TestGroup {
 			http2Conn.fr.WriteData(1, true, []byte(dummyData(16385)))
 
 			actualCodes := []http2.ErrCode{http2.ErrCodeFrameSize}
-			return TestConnectionError(ctx, http2Conn, actualCodes)
+			return TestStreamError(ctx, http2Conn, actualCodes)
 		},
 	))
 


### PR DESCRIPTION
The test sends an oversized data frame, so the server is required
to reset the stream with FRAME_SIZE_ERROR.
The server may treat this error as fatal for the connection and send
GOAWAY( FRAME_SIZE_ERROR ), or drop the connection instead.

These upgraded errors are already handled by TestStreamError