### PR TITLE
set `SETTING_INITIAL_WINDOW_SIZE` to zero in concurrency test (5.1.2)

### DIFF
--- a/5_1.go
+++ b/5_1.go
@@ -1,6 +1,7 @@
 package h2spec
 
 import (
+        "fmt"
 	"github.com/bradfitz/http2"
 	"github.com/bradfitz/http2/hpack"
 )
@@ -367,6 +368,10 @@ func StreamConcurrencyTestGroup() *TestGroup {
 				return nil, actual
 			}
 
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from closing the stream
+			fmt.Fprintf(http2Conn.conn, "\x00\x00\x06\x04\x00\x00\x00\x00\x00")
+			fmt.Fprintf(http2Conn.conn, "\x00\x04\x00\x00\x00\x00")
+
 			hdrs := []hpack.HeaderField{
 				pair(":method", "GET"),
 				pair(":scheme", "http"),
@@ -380,7 +385,7 @@ func StreamConcurrencyTestGroup() *TestGroup {
 				var hp http2.HeadersFrameParam
 				hp.StreamID = streamID
 				hp.EndStream = true
-				hp.EndHeaders = false
+				hp.EndHeaders = true
 				hp.BlockFragment = hbf
 				http2Conn.fr.WriteHeaders(hp)
 				streamID += 2


### PR DESCRIPTION
The PR changes the strategy for testing the behavior of the server in case the number of open streams exceed the limit, to setting `SETTING_INITIAL_WINDOW_SIZE` to zero and then opening the streams, from trying to exceed the number of open streams by not setting the `END_HEADERS` flag of the `HEADERS` frames being sent.  The original approach (of sending such HEADERS frames continuously) is a violation of HTTP/2 spec. 6.2 that is handled by peer as a `PROTOCOL_ERROR`.

originally reported as: https://github.com/h2o/h2o/issues/268#issuecomment-90135116

PS. the original report complains about what seems like an `ECONNRESET` error which I am unable to reproduce (it is unsurprising consireding the nature that `RST` packet (the cause of the error) would only be sent if the server receives data _after_ the socket is being `close(2)`ed).  While I believe that the error on the reporters environment would disappear once this PR gets merged (since with the modified code a server compliant to the HTTP/2 spec. would no longer close the connection until receiving the last frame sent by the client), it might worth reviewing the source code of h2spec to see if there would be any case where the test might end up with `ECONNRESET` as a form of socket close (in addition to `read()` returning zero).

Cc @devlearner