### PR TITLE
Use HEADERS frame without END_STREAM in concurrency test (5.1.2)

### DIFF
--- a/5_1.go
+++ b/5_1.go
@@ -379,8 +379,8 @@ func StreamConcurrencyTestGroup() *TestGroup {
 			for i := 0; i <= int(http2Conn.Settings[http2.SettingMaxConcurrentStreams]); i++ {
 				var hp http2.HeadersFrameParam
 				hp.StreamID = streamID
-				hp.EndStream = true
-				hp.EndHeaders = false
+				hp.EndStream = false
+				hp.EndHeaders = true
 				hp.BlockFragment = hbf
 				http2Conn.fr.WriteHeaders(hp)
 				streamID += 2


### PR DESCRIPTION
This PR fixes #24 by using HEADERS frame without END_STREAM flag.