### PR TITLE
Test 4.2: use the max frame size from the server's SETTINGS frame

### DIFF
--- a/4_2.go
+++ b/4_2.go
@@ -12,10 +12,8 @@ func FrameSizeTestGroup() *TestGroup {
 		"Sends large size frame that exceeds the SETTINGS_MAX_FRAME_SIZE",
 		"The endpoint MUST send a FRAME_SIZE_ERROR error.",
 		func(ctx *Context) (expected []Result, actual Result) {
-			http2Conn := CreateHttp2Conn(ctx, false)
+			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
-
-			http2Conn.fr.WriteSettings()
 
 			hdrs := []hpack.HeaderField{
 				pair(":method", "GET"),
@@ -30,7 +28,12 @@ func FrameSizeTestGroup() *TestGroup {
 			hp.EndHeaders = true
 			hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 			http2Conn.fr.WriteHeaders(hp)
-			http2Conn.fr.WriteData(1, true, []byte(dummyData(16385)))
+			max_size, ok := http2Conn.Settings[http2.SettingMaxFrameSize]
+			if( !ok ) {
+				max_size = 18384
+			}
+
+			http2Conn.fr.WriteData(1, true, []byte(dummyData(int(max_size) + 1)))
 
 			actualCodes := []http2.ErrCode{http2.ErrCodeFrameSize}
 			return TestStreamError(ctx, http2Conn, actualCodes)


### PR DESCRIPTION
The test now does a settings handshake and uses the server's settings
to determine the max frame size (then sends a frame 1 byte longer).

Previously the test used the value of the default setting.