### PR TITLE
Fix tests

### DIFF
--- a/5_1.go
+++ b/5_1.go
@@ -127,20 +127,18 @@ func StreamStatesTestGroup(ctx *Context) *TestGroup {
 			defer http2Conn.conn.Close()
 
 			hdrs := commonHeaderFields(ctx)
-			hdrs = append(hdrs, pair("x-dummy1", dummyData(10000)))
-			hdrs = append(hdrs, pair("x-dummy2", dummyData(10000)))
 			blockFragment := http2Conn.EncodeHeader(hdrs)
 
 			var hp http2.HeadersFrameParam
 			hp.StreamID = 1
 			hp.EndStream = true
 			hp.EndHeaders = true
-			hp.BlockFragment = blockFragment[0:16384]
+			hp.BlockFragment = blockFragment
 			http2Conn.fr.WriteHeaders(hp)
 
-			http2Conn.fr.WriteContinuation(1, true, blockFragment[16384:])
+			http2Conn.fr.WriteContinuation(1, true, blockFragment)
 
-			actualCodes := []http2.ErrCode{http2.ErrCodeStreamClosed}
+			actualCodes := []http2.ErrCode{http2.ErrCodeStreamClosed, http2.ErrCodeProtocol}
 			return TestStreamError(ctx, http2Conn, actualCodes)
 		},
 	))
@@ -235,7 +233,7 @@ func StreamStatesTestGroup(ctx *Context) *TestGroup {
 
 			http2Conn.fr.WriteContinuation(1, true, blockFragment[16384:])
 
-			actualCodes := []http2.ErrCode{http2.ErrCodeStreamClosed}
+			actualCodes := []http2.ErrCode{http2.ErrCodeStreamClosed, http2.ErrCodeProtocol}
 			return TestStreamError(ctx, http2Conn, actualCodes)
 		},
 	))

--- a/6_10.go
+++ b/6_10.go
@@ -240,7 +240,7 @@ func ContinuationTestGroup(ctx *Context) *TestGroup {
 			hp.BlockFragment = http2Conn.EncodeHeader(hdrs)
 			http2Conn.fr.WriteHeaders(hp)
 
-			http2Conn.fr.WriteData(1, true, []byte("test"))
+			http2Conn.fr.WriteData(1, false, []byte("test"))
 			http2Conn.fr.WriteContinuation(1, true, http2Conn.EncodeHeader(hdrs))
 
 			actualCodes := []http2.ErrCode{http2.ErrCodeProtocol}


### PR DESCRIPTION
Tests in 5.1, sending CONTINUATION in closed or half-closed (remote)
state, are controversial.  For instance, 5.1 says receiving frames
other than WINDOW_UPDATE, PRIORITY or RST_STREAM in half-closed
(remote) must be treated as STREAM_CLOSED, but 6.10 also says that

"""
A CONTINUATION frame MUST be preceded by a HEADERS, PUSH_PROMISE or
CONTINUATION frame without the END_HEADERS flag set.  A recipient
that observes violation of this rule MUST respond with a connection
error (Section 5.4.1) of type PROTOCOL_ERROR.
"""

END_HEADERS flag set implies END_STREAM flag set.  So receiving
CONTINUATION after END_HEADERS set and END_STREAM set (half-closed
(remote)) must be treated as PROTOCOL_ERROR.

They seem contradict each other.  So I suggest to add PROTOCOL_ERROR
as acceptable error code for these tests.

The fix in 5.10 (half-closed (remote)) is avoid the implementation to
emit COMPRESSION_ERROR, because we set END_HEADERS in HEADERS frame,
which means we have to supply complete header block to it.

For test in 6.10, we must not close stream with END_STREAM flag set in
DATA.  If we do that, it is completely valid for the implementation to
emit STREAM_CLOSED error code.  To fix this, remove END_STREAM flag.
This ensures that implementation will emit PROTOCOL_ERROR for
unexpected CONTINUATION.