### PR TITLE
Test 5.3.1: use a stream ID that is valid

### DIFF
--- a/5_3.go
+++ b/5_3.go
@@ -25,12 +25,12 @@ func StreamDependenciesTestGroup(ctx *Context) *TestGroup {
 			hdrs := commonHeaderFields(ctx)
 
 			var pp http2.PriorityParam
-			pp.StreamDep = 2
+			pp.StreamDep = 3
 			pp.Exclusive = false
 			pp.Weight = 255
 
 			var hp http2.HeadersFrameParam
-			hp.StreamID = 2
+			hp.StreamID = 3
 			hp.EndStream = true
 			hp.EndHeaders = true
 			hp.Priority = pp


### PR DESCRIPTION
The test previously used stream ID 2, which is not valid for client
initiated streams.
Now it uses stream ID 3 to ensure that the only problem with the HEADERS
frame is the priority dependency on itself.