### PR TITLE
Add HPACK related tests

### DIFF
--- a/4_3.go
+++ b/4_3.go
@@ -23,5 +23,58 @@ func HeaderCompressionAndDecompressionTestGroup(ctx *Context) *TestGroup {
 		},
 	))
 
+	tg.AddTestCase(NewTestCase(
+		"Sends Dynamic Table Size Update (RFC 7541, 6.3)",
+		"The endpoint must accept Dynamic Table Size Update",
+		func(ctx *Context) (pass bool, expected []Result, actual Result) {
+			http2Conn := CreateHttp2Conn(ctx, true)
+			defer http2Conn.conn.Close()
+
+			hdrs := commonHeaderFields(ctx)
+
+			// 2 Dynamic Table Size Updates, 0 and 4096.
+			blockFragment := []byte{0x20, 0x3f, 0xe1, 0x1f}
+			blockFragment = append(blockFragment, http2Conn.EncodeHeader(hdrs)...)
+			var hp http2.HeadersFrameParam
+			hp.StreamID = 1
+			hp.EndStream = true
+			hp.EndHeaders = true
+			hp.BlockFragment = blockFragment
+			http2Conn.fr.WriteHeaders(hp)
+
+			return TestStreamClose(ctx, http2Conn)
+		},
+	))
+
+	tg.AddTestCase(NewTestCase(
+		"Encodes Dynamic Table Size Update (RFC 7541, 6.3) after common header fields",
+		"The endpoint MUST terminate the connection with a connection error of type COMPRESSION_ERROR.",
+		func(ctx *Context) (pass bool, expected []Result, actual Result) {
+			http2Conn := CreateHttp2Conn(ctx, true)
+			defer http2Conn.conn.Close()
+
+			hdrs := commonHeaderFields(ctx)
+
+			blockFragment := http2Conn.EncodeHeader(hdrs)
+			// append 2 Dynamic Table Size Updates, 0 and
+			// 4096.  this is illegal, since RFC 7541,
+			// section 4.2 says that dynamic table size
+			// update MUST occur at the beginning of the
+			// first header block following the changes to
+			// the dynamic table size.
+			blockFragment = append(blockFragment, 0x20, 0x3f, 0xe1, 0x1f)
+
+			var hp http2.HeadersFrameParam
+			hp.StreamID = 1
+			hp.EndStream = true
+			hp.EndHeaders = true
+			hp.BlockFragment = blockFragment
+			http2Conn.fr.WriteHeaders(hp)
+
+			actualCodes := []http2.ErrCode{http2.ErrCodeCompression}
+			return TestConnectionError(ctx, http2Conn, actualCodes)
+		},
+	))
+
 	return tg
 }

--- a/6_5.go
+++ b/6_5.go
@@ -23,8 +23,12 @@ func SettingsTestGroup(ctx *Context) *TestGroup {
 			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
 
-			settings := http2.Setting{http2.SettingMaxConcurrentStreams, 100}
-			http2Conn.fr.WriteSettings(settings)
+			settings := []http2.Setting{
+				http2.Setting{http2.SettingMaxConcurrentStreams, 100},
+				// sends 4GiB size for sanity check
+				http2.Setting{http2.SettingHeaderTableSize, ^uint32(0)},
+			}
+			http2Conn.fr.WriteSettings(settings...)
 
 		loop:
 			for {


### PR DESCRIPTION
2 tests regarding Dynamic Table Size Update were added to 4.3.  First
test ensures that implementation can accept Dynamic Table Size update.
Second test ensures that implementation rejects Dynamic Table Size if
it does not appear at the beginning of the first header block (see
http://tools.ietf.org/html/rfc7541#section-4.2).

I modified 6.3 SETTINGS test to include SETTINGS_HEADER_TABLE_SIZE
with value 4GiB for sanity check.