### PR TITLE
6.1 says MUST treat this as a connection error

### DIFF
--- a/6_1.go
+++ b/6_1.go
@@ -69,7 +69,7 @@ func DataTestGroup(ctx *Context) *TestGroup {
 			fmt.Fprintf(http2Conn.conn, "\x06\x54\x65\x73\x74")
 
 			actualCodes := []http2.ErrCode{http2.ErrCodeProtocol}
-			return TestStreamError(ctx, http2Conn, actualCodes)
+			return TestConnectionError(ctx, http2Conn, actualCodes)
 		},
 	))
 


### PR DESCRIPTION
Your test description is right, but the code was looking for a stream
level error

I'm not sure this is even working right. The output still looks like this:

```
  6.1. DATA
    × Sends a DATA frame with invalid pad length
      - The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.
        Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                  RST_STREAM frame (ErrorCode: PROTOCOL_ERROR)
                  Connection close
          Actual: DATA frame (Length: 16, Flags: 1)
```

but I think it should look like this: 

```
  6.1. DATA
    × Sends a DATA frame with invalid pad length
      - The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.
        Expected: GOAWAY frame (ErrorCode: PROTOCOL_ERROR)
                  Connection close
          Actual: DATA frame (Length: 16, Flags: 1)
```