### PR TITLE
Add support for junit test out

### DIFF
--- a/cmd/h2spec/h2spec.go
+++ b/cmd/h2spec/h2spec.go
@@ -30,6 +30,7 @@ func main() {
 	insecureSkipVerify := flag.Bool("k", false, "Don't verify server's certificate.")
 	timeout := flag.Int("o", 2, "Maximum time allowed for test.")
 	strict := flag.Bool("S", false, "Strict mode.")
+	junit := flag.String("j", "", "Create test report also in JUnit format.")
 	version := flag.Bool("version", false, "Display version information and exit.")
 
 	var sectionFlag sections
@@ -45,6 +46,7 @@ func main() {
 		fmt.Println("  -o:        Maximum time allowed for test. (Default: 2)")
 		fmt.Println("  -s:        Section number on which to run the test. (Example: -s 6.1 -s 6.2)")
 		fmt.Println("  -S:        Run the test cases marked as \"strict\".")
+		fmt.Println("  -j:        Creates report also in JUnit format into specified file.")
 		fmt.Println("  --version: Display version information and exit.")
 		fmt.Println("  --help:    Display this help and exit.")
 		os.Exit(1)
@@ -70,6 +72,7 @@ func main() {
 	ctx.Host = *host
 	ctx.Timeout = time.Duration(*timeout) * time.Second
 	ctx.Strict = *strict
+	ctx.Junit = *junit
 	ctx.Tls = *useTls
 	ctx.TlsConfig = &tls.Config{
 		InsecureSkipVerify: *insecureSkipVerify,

--- a/h2spec.go
+++ b/h2spec.go
@@ -93,6 +93,9 @@ func (tg *TestGroup) Run(ctx *Context) bool {
 		}
 		tg.PrintFooter()
 	} else {
+		for _, testCase := range tg.testCases {
+			testCase.skipped = true
+		}
 		tg.numSkipped += tg.numTestCases
 	}
 
@@ -201,6 +204,7 @@ type TestCase struct {
 	Spec     string
 	handler  func(*Context) (bool, []Result, Result)
 	failed   bool     // true if test failed
+	skipped  bool     // true if test has been skipped
 	expected []Result // expected result
 	actual   Result   // actual result
 	testTime time.Duration  // length of test execution
@@ -218,6 +222,8 @@ func (tc *TestCase) Run(ctx *Context) TestResult {
 
 	_, ok := actual.(*ResultSkipped)
 	if ok {
+		tc.skipped = true
+		tc.testTime = time.Duration(0)
 		tc.PrintSkipped(actual)
 		logger.LevelDown()
 		return Skipped

--- a/h2spec.go
+++ b/h2spec.go
@@ -203,6 +203,7 @@ type TestCase struct {
 	failed   bool     // true if test failed
 	expected []Result // expected result
 	actual   Result   // actual result
+	testTime time.Duration  // length of test execution
 }
 
 func (tc *TestCase) Run(ctx *Context) TestResult {
@@ -210,7 +211,11 @@ func (tc *TestCase) Run(ctx *Context) TestResult {
 
 	tc.PrintEphemeralDesc()
 
+	startingTime := time.Now().UTC()
 	pass, expected, actual := tc.handler(ctx)
+	endingTime := time.Now().UTC()
+	tc.testTime = endingTime.Sub(startingTime)
+
 	_, ok := actual.(*ResultSkipped)
 	if ok {
 		tc.PrintSkipped(actual)


### PR DESCRIPTION
I have added support to generate results of test also in JUnit format to easily connect this testsuite e.g. with Jenkins.

By default file in current directory named 'report.xml' is created. User can change this default with '-j' option. Please provide your opinion and possible suggestions.