### PR TITLE
Send Content-Length header in test 6.1

### DIFF
--- a/6_1.go
+++ b/6_1.go
@@ -31,7 +31,7 @@ func DataTestGroup(ctx *Context) *TestGroup {
 
 			hdrs := commonHeaderFields(ctx)
 			hdrs[0].Value = "POST"
-			hdrs = append(hdrs, pair("content-type", "4"))
+			hdrs = append(hdrs, pair("content-length", "4"))
 
 			var hp http2.HeadersFrameParam
 			hp.StreamID = 1
@@ -55,7 +55,7 @@ func DataTestGroup(ctx *Context) *TestGroup {
 
 			hdrs := commonHeaderFields(ctx)
 			hdrs[0].Value = "POST"
-			hdrs = append(hdrs, pair("content-type", "4"))
+			hdrs = append(hdrs, pair("content-length", "4"))
 
 			var hp http2.HeadersFrameParam
 			hp.StreamID = 1


### PR DESCRIPTION
`h2spec` is sending `content-type: 4` header In test cases of 6.1. It looks like this is a typo of `content-length: 4`.
