### PR TITLE
Make sure stream states are open

### DIFF
--- a/4_2.go
+++ b/4_2.go
@@ -14,6 +14,10 @@ func FrameSizeTestGroup(ctx *Context) *TestGroup {
 			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
 
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from closing the stream
+			settings := http2.Setting{http2.SettingInitialWindowSize, 0}
+			http2Conn.fr.WriteSettings(settings)
+
 			hdrs := commonHeaderFields(ctx)
 
 			var hp http2.HeadersFrameParam

--- a/6_10.go
+++ b/6_10.go
@@ -254,6 +254,10 @@ func ContinuationTestGroup(ctx *Context) *TestGroup {
 			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
 
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from closing the stream
+			settings := http2.Setting{http2.SettingInitialWindowSize, 0}
+			http2Conn.fr.WriteSettings(settings)
+
 			hdrs := commonHeaderFields(ctx)
 
 			var hp http2.HeadersFrameParam

--- a/6_3.go
+++ b/6_3.go
@@ -40,6 +40,10 @@ func PriorityTestGroup(ctx *Context) *TestGroup {
 			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
 
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from closing the stream
+			settings := http2.Setting{http2.SettingInitialWindowSize, 0}
+			http2Conn.fr.WriteSettings(settings)
+
 			hdrs := commonHeaderFields(ctx)
 
 			var hp http2.HeadersFrameParam

--- a/6_4.go
+++ b/6_4.go
@@ -43,6 +43,10 @@ func RstStreamTestGroup(ctx *Context) *TestGroup {
 			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
 
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from closing the stream
+			settings := http2.Setting{http2.SettingInitialWindowSize, 0}
+			http2Conn.fr.WriteSettings(settings)
+
 			hdrs := commonHeaderFields(ctx)
 
 			var hp http2.HeadersFrameParam

--- a/6_9.go
+++ b/6_9.go
@@ -138,6 +138,10 @@ func WindowUpdateTestGroup(ctx *Context) *TestGroup {
 			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
 
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from closing the stream
+			settings := http2.Setting{http2.SettingInitialWindowSize, 0}
+			http2Conn.fr.WriteSettings(settings)
+
 			hdrs := commonHeaderFields(ctx)
 
 			var hp http2.HeadersFrameParam

--- a/8_1.go
+++ b/8_1.go
@@ -168,6 +168,10 @@ func HttpRequestResponseExchangeTestGroup(ctx *Context) *TestGroup {
 			http2Conn := CreateHttp2Conn(ctx, true)
 			defer http2Conn.conn.Close()
 
+			// Set INITIAL_WINDOW_SIZE to zero to prevent the peer from closing the stream
+			settings := http2.Setting{http2.SettingInitialWindowSize, 0}
+			http2Conn.fr.WriteSettings(settings)
+
 			hdrs := commonHeaderFields(ctx)
 			hdrs[0].Value = "POST"
 			hdrs = append(hdrs, pair("trailer", "x-test"))


### PR DESCRIPTION
# Issues
In some tests, it looks like h2spec assumes that server side stream state is *open* after sending HEADERS frame with END_HEADERS flag and without END_STREAM flag. (e.g. [6.4 Sends a RST_STREAM frame with a length other than 4 octets](https://github.com/summerwind/h2spec/blob/master/6_4.go#L40-L61) )
But the server side stream state could be *half-close (local)*, because server implementations can send responses immediately after receiving HEADERS frame. In this situation, responses could be unexpected.

# Proposals  
To make sure the server side stream state is *open*, change HTTP method POST and add a content-length header in some tests.