### PR TITLE
Fix for issue #63, Test error string / spec.TestError

### DIFF
--- a/reporter/junit_report.go
+++ b/reporter/junit_report.go
@@ -98,13 +98,20 @@ func convertJUnitReport(groups []*spec.TestGroup) []*JUnitTestSuite {
 				jtc.Skipped = &JUnitSkipped{}
 			} else if tc.Result.Failed {
 				jts.Failures += 1
+				switch tc.Result.Error.(type) {
+				case spec.TestError:
+					err := tc.Result.Error.(*spec.TestError)
+					expected := strings.Join(err.Expected, "\n")
+					actual := err.Actual
 
-				err := tc.Result.Error.(*spec.TestError)
-				expected := strings.Join(err.Expected, "\n")
-				actual := err.Actual
-
-				jtc.Failure = &JUnitFailure{
-					Content: fmt.Sprintf("Expect:\n%s\nActual:\n%s", expected, actual),
+					jtc.Failure = &JUnitFailure{
+						Content: fmt.Sprintf("Expect:\n%s\nActual:\n%s", expected, actual),
+					}
+				default:
+					err := tc.Result.Error
+					jtc.Failure = &JUnitFailure{
+						Content: fmt.Sprintf("Test in Error: %s", err),
+					}
 				}
 			}
 


### PR DESCRIPTION
See #63 , it works now:

```
<testsuite name="5.1.2. Stream Concurrency" package="http2/5.1.2" id="5.1.2" tests="1" skipped="0" failures="1" errors="0">
  <testcase package="http2/5.1.2" classname="Sends HEADERS frames that causes their advertised concurrent stream limit to be exceeded" time="2.0001">
    <failure>Test in Error: Timeout</failure>
  </testcase>
</testsuite>
```