### PR TITLE
Display Error message instead of crashing on Timeout.

### DIFF
--- a/spec/spec.go
+++ b/spec/spec.go
@@ -241,8 +241,11 @@ func (tr *TestResult) Print() {
 
 		return
 	}
-
-	log.Println(red(fmt.Sprintf("Error: %v", err)))
+	if (err == nil) {
+		log.Println(red(fmt.Sprintf("Error: %v", tr.Error.Error())))
+	} else {
+		log.Println(red(fmt.Sprintf("Error: %v", err)))
+	}
 }
 
 func seqStr(seq int) string {


### PR DESCRIPTION
Follow up on #63, this time for the regular Reporter.

# Expected
```
Hypertext Transfer Protocol Version 2 (HTTP/2)
  3. Starting HTTP/2
    3.3. Starting HTTP/2 for "https" URIs
           <-- [send] SETTINGS Frame (length:6, flags:0x00, stream_id:0)
      × 1: A client that makes a request to an "https" URI uses TLS with ALPN.
      Error: Timeout
```
# Actual
```
Hypertext Transfer Protocol Version 2 (HTTP/2)
  3. Starting HTTP/2
    3.3. Starting HTTP/2 for "https" URIs
           <-- [send] SETTINGS Frame (length:6, flags:0x00, stream_id:0)
      × 1: A client that makes a request to an "https" URI uses TLS with ALPN.
      Error: <nil>
```