### PR TITLE
Treat as connection error with invalid pad length

### DIFF
--- a/http2/6_1_data.go
+++ b/http2/6_1_data.go
@@ -94,7 +94,7 @@ func Data() *spec.TestGroup {
 			conn.Send([]byte("\x00\x00\x05\x00\x09\x00\x00\x00\x01"))
 			conn.Send([]byte("\x06\x54\x65\x73\x74"))
 
-			return spec.VerifyStreamError(conn, http2.ErrCodeProtocol)
+			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
 		},
 	})
 


### PR DESCRIPTION
A minor fixed about verify server handling invalid padding length.

The third test case of 6.1 said it should treat as a connection error when receiving DATA frame that had invalid padding length.
But the test case verify it with stream error.