### PR TITLE
h2specd: Moved handshaking into test cases

### DIFF
--- a/client/1_starting_http2.go
+++ b/client/1_starting_http2.go
@@ -9,12 +9,11 @@ func StartingHTTP2() *spec.ClientTestGroup {
 	tg := NewTestGroup("1", "Starting HTTP/2")
 
 	tg.AddTestCase(&spec.ClientTestCase{
-		Desc:        "Sends a client connection preface",
-		Requirement: "The endpoint MUST accept client connection preface.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
-			conn.WriteSuccessResponse(req.StreamID, c)
-
-			return nil
+		Desc:        "Sends a server connection preface",
+		Requirement: "The endpoint MUST accept server connection preface.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			return err
 		},
 	})
 

--- a/client/4_1_frame_format.go
+++ b/client/4_1_frame_format.go
@@ -14,13 +14,16 @@ func FrameFormat() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a frame with unknown type",
 		Requirement: "The endpoint MUST ignore and discard any frame that has a type that is unknown.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// UNKONWN Frame:
 			// Length: 8, Type: 255, Flags: 0, R: 0, StreamID: 0
 			conn.Send([]byte("\x00\x00\x08\x16\x00\x00\x00\x00\x00"))
 			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
-
-			defer conn.WriteSuccessResponse(req.StreamID, c)
 
 			data := [8]byte{}
 			conn.WritePing(false, data)
@@ -36,13 +39,16 @@ func FrameFormat() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a frame with undefined flag",
 		Requirement: "The endpoint MUST ignore any flags that is undefined.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// PING Frame:
 			// Length: 8, Type: 6, Flags: 255, R: 0, StreamID: 0
 			conn.Send([]byte("\x00\x00\x08\x06\x16\x00\x00\x00\x00"))
 			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
-
-			defer conn.WriteSuccessResponse(req.StreamID, c)
 
 			return spec.VerifyEventType(conn, spec.EventPingFrame)
 		},
@@ -54,13 +60,16 @@ func FrameFormat() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a frame with reserved field bit",
 		Requirement: "The endpoint MUST ignore the value of reserved field.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// PING Frame:
 			// Length: 8, Type: 6, Flags: 255, R: 1, StreamID: 0
 			conn.Send([]byte("\x00\x00\x08\x06\x16\x80\x00\x00\x00"))
 			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
-
-			defer conn.WriteSuccessResponse(req.StreamID, c)
 
 			return spec.VerifyEventType(conn, spec.EventPingFrame)
 		},

--- a/client/4_2_frame_size.go
+++ b/client/4_2_frame_size.go
@@ -15,7 +15,17 @@ func FrameSize() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a DATA frame with 2^14 octets in length",
 		Requirement: "The endpoint MUST be capable of receiving and minimally processing frames up to 2^14 octets in length.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 
 			hp := http2.HeadersFrameParam{
@@ -44,7 +54,17 @@ func FrameSize() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a large size DATA frame that exceeds the SETTINGS_MAX_FRAME_SIZE",
 		Requirement: "The endpoint MUST send an error code of FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 
 			hp := http2.HeadersFrameParam{
@@ -71,7 +91,17 @@ func FrameSize() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a large size HEADERS frame that exceeds the SETTINGS_MAX_FRAME_SIZE",
 		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			headers = append(headers, spec.DummyRespHeaders(c, 5)...)
 

--- a/client/4_3_header_compression_and_decompression.go
+++ b/client/4_3_header_compression_and_decompression.go
@@ -17,7 +17,17 @@ func HeaderCompressionAndDecompression() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends invalid header block fragment",
 		Requirement: "The endpoint MUST terminate the connection with a connection error of type COMPRESSION_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			// Literal Header Field with Incremental Indexing without
 			// Length and String segment.
 			data := new(bytes.Buffer)
@@ -25,7 +35,7 @@ func HeaderCompressionAndDecompression() *spec.ClientTestGroup {
 			binary.Write(data, binary.LittleEndian, req.StreamID)
 			data.Write([]byte{0x40})
 
-			err := conn.Send(data.Bytes())
+			err = conn.Send(data.Bytes())
 			if err != nil {
 				return err
 			}

--- a/client/5_1_1_stream_identifiers.go
+++ b/client/5_1_1_stream_identifiers.go
@@ -13,12 +13,17 @@ func StreamIdentifiers() *spec.ClientTestGroup {
 	// MUST respond with a connection error (Section 5.4.1) of
 	// type PROTOCOL_ERROR.
 	tg.AddTestCase(&spec.ClientTestCase{
-		Desc:        "Sends odd-numbered stream identifier",
+		Desc:        "Sends even-numbered stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
-				StreamID:      req.StreamID + 2,
+				StreamID:      101,
 				EndStream:     true,
 				EndHeaders:    true,
 				BlockFragment: conn.EncodeHeaders(headers),

--- a/client/5_1_stream_states.go
+++ b/client/5_1_stream_states.go
@@ -16,7 +16,12 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "idle: Sends a DATA frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteData(2, true, []byte("test"))
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
@@ -30,7 +35,12 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "idle: Sends a RST_STREAM frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteRSTStream(2, http2.ErrCodeCancel)
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
@@ -44,7 +54,12 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "idle: Sends a WINDOW_UPDATE frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteWindowUpdate(2, 100)
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
@@ -58,7 +73,12 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "idle: Sends a CONTINUATION frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			blockFragment := conn.EncodeHeaders(headers)
 			conn.WriteContinuation(2, true, blockFragment)
@@ -74,7 +94,17 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "closed: Sends a DATA frame after sending RST_STREAM frame",
 		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -99,7 +129,17 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "closed: Sends a HEADERS frame after sending RST_STREAM frame",
 		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp1 := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -130,7 +170,17 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "closed: Sends a CONTINUATION frame after sending RST_STREAM frame",
 		Requirement: "The endpoint MUST treat this as a stream error of type STREAM_CLOSED.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -160,7 +210,17 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "closed: Sends a DATA frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -183,7 +243,17 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "closed: Sends a HEADERS frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -206,7 +276,17 @@ func StreamStates() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "closed: Sends a CONTINUATION frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type STREAM_CLOSED.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,

--- a/client/5_4_1_connection_error_handling.go
+++ b/client/5_4_1_connection_error_handling.go
@@ -17,7 +17,12 @@ func ConnectionErrorHandling() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends an invalid PING frame for connection close",
 		Requirement: "The endpoint MUST close the TCP connection",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// PING frame with invalid stream ID
 			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x03"))
 			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
@@ -32,7 +37,12 @@ func ConnectionErrorHandling() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends an invalid PING frame to receive GOAWAY frame",
 		Requirement: "An endpoint that encounters a connection error SHOULD first send a GOAWAY frame",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// PING frame with invalid stream ID
 			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x03"))
 			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))

--- a/client/5_5_extending_http2.go
+++ b/client/5_5_extending_http2.go
@@ -11,14 +11,16 @@ func ExtendingHTTP2() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends an unknown extension frame",
 		Requirement: "The endpoint MUST ignore unknown or unsupported values in all extensible protocol elements.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
 
 			// UNKONWN Frame:
 			// Length: 8, Type: 255, Flags: 0, R: 0, StreamID: 0
 			conn.Send([]byte("\x00\x00\x08\x16\x00\x00\x00\x00\x00"))
 			conn.Send([]byte("\x00\x00\x00\x00\x00\x00\x00\x00"))
-
-			defer conn.WriteSuccessResponse(req.StreamID, c)
 
 			data := [8]byte{}
 			conn.WritePing(false, data)

--- a/client/6_10_continuation.go
+++ b/client/6_10_continuation.go
@@ -18,7 +18,17 @@ func Continuation() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends multiple CONTINUATION frames preceded by a HEADERS frame",
 		Requirement: "The endpoint must accept the frame.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -47,7 +57,17 @@ func Continuation() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a CONTINUATION frame followed by any frame other than CONTINUATION",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 
 			hp := http2.HeadersFrameParam{
@@ -73,7 +93,17 @@ func Continuation() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a CONTINUATION frame with 0x0 stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -97,7 +127,17 @@ func Continuation() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a CONTINUATION frame preceded by a HEADERS frame with END_HEADERS flag",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -121,7 +161,17 @@ func Continuation() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a CONTINUATION frame preceded by a CONTINUATION frame with END_HEADERS flag",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -146,7 +196,17 @@ func Continuation() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a CONTINUATION frame preceded by a DATA frame",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 
 			hp := http2.HeadersFrameParam{

--- a/client/6_1_data.go
+++ b/client/6_1_data.go
@@ -17,7 +17,12 @@ func Data() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a DATA frame with 0x0 stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteData(0, true, []byte("test"))
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
@@ -32,7 +37,17 @@ func Data() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a DATA frame on the stream that is not in \"open\" or \"half-closed (local)\" state",
 		Requirement: "The endpoint MUST respond with a stream error of type STREAM_CLOSED.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 
 			hp := http2.HeadersFrameParam{
@@ -55,7 +70,17 @@ func Data() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a DATA frame with invalid pad length",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			headers = append(headers, spec.HeaderField("content-length", "4"))
 

--- a/client/6_2_headers.go
+++ b/client/6_2_headers.go
@@ -21,7 +21,17 @@ func Headers() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a HEADERS frame without the END_HEADERS flag, and a PRIORITY frame",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -52,7 +62,12 @@ func Headers() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a HEADERS frame with 0x0 stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 
 			hp := http2.HeadersFrameParam{
@@ -75,7 +90,17 @@ func Headers() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a HEADERS frame with invalid pad length",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 
 			// HEADERS frame:

--- a/client/6_3_priority.go
+++ b/client/6_3_priority.go
@@ -17,7 +17,12 @@ func Priority() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a PRIORITY frame with 0x0 stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			pp := http2.PriorityParam{
 				StreamDep: 0,
 				Exclusive: false,
@@ -35,7 +40,17 @@ func Priority() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a PRIORITY frame with a length other than 5 octets",
 		Requirement: "The endpoint MUST respond with a stream error of type FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,

--- a/client/6_4_rst_stream.go
+++ b/client/6_4_rst_stream.go
@@ -17,7 +17,12 @@ func RSTStream() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a RST_STREAM frame with 0x0 stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteRSTStream(0, http2.ErrCodeCancel)
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
@@ -31,7 +36,12 @@ func RSTStream() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a RST_STREAM frame on a idle stream",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteRSTStream(2, http2.ErrCodeCancel)
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
@@ -44,7 +54,17 @@ func RSTStream() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a RST_STREAM frame with a length other than 4 octets",
 		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,

--- a/client/6_5_2_defined_settings_parameters.go
+++ b/client/6_5_2_defined_settings_parameters.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"golang.org/x/net/http2"
 
 	"github.com/summerwind/h2spec/config"
@@ -17,7 +18,17 @@ func DefinedSETTINGSParameters() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "SETTINGS_INITIAL_WINDOW_SIZE (0x4): Sends the value above the maximum flow control window size",
 		Requirement: "The endpoint MUST treat this as a connection error of type FLOW_CONTROL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			setting := http2.Setting{
 				ID:  http2.SettingInitialWindowSize,
 				Val: 2147483648,
@@ -37,7 +48,17 @@ func DefinedSETTINGSParameters() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value below the initial value",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			setting := http2.Setting{
 				ID:  http2.SettingMaxFrameSize,
 				Val: 16383,
@@ -57,7 +78,17 @@ func DefinedSETTINGSParameters() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "SETTINGS_MAX_FRAME_SIZE (0x5): Sends the value above the maximum allowed frame size",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			setting := http2.Setting{
 				ID:  http2.SettingMaxFrameSize,
 				Val: 16777216,
@@ -73,7 +104,17 @@ func DefinedSETTINGSParameters() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a SETTINGS frame with unknown identifier",
 		Requirement: "The endpoint MUST ignore that setting.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			setting := http2.Setting{
 				ID:  0xFF,
 				Val: 1,

--- a/client/6_5_3_settings_synchronization.go
+++ b/client/6_5_3_settings_synchronization.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"golang.org/x/net/http2"
 
 	"github.com/summerwind/h2spec/config"
@@ -15,10 +16,20 @@ func SettingsSynchronization() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a SETTINGS frame without ACK flag",
 		Requirement: "The endpoint MUST immediately emit a SETTINGS frame with the ACK flag set.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			setting := http2.Setting{
-				ID:  http2.SettingEnablePush,
-				Val: 0,
+				ID:  http2.SettingMaxConcurrentStreams,
+				Val: 100,
 			}
 			conn.WriteSettings(setting)
 

--- a/client/6_5_settings.go
+++ b/client/6_5_settings.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"golang.org/x/net/http2"
 
 	"github.com/summerwind/h2spec/config"
@@ -20,7 +21,17 @@ func Settings() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a SETTINGS frame with ACK flag and payload",
 		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			// SETTINGS frame:
 			// length: 0, flags: 0x1, stream_id: 0x0
 			conn.Send([]byte("\x00\x00\x01\x04\x01\x00\x00\x00\x00"))
@@ -39,7 +50,17 @@ func Settings() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a SETTINGS frame with a stream identifier other than 0x0",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			// SETTINGS frame:
 			// length: 6, flags: 0x0, stream_id: 0x1
 			conn.Send([]byte("\x00\x00\x06\x04\x00\x00\x00\x00\x01"))
@@ -59,7 +80,17 @@ func Settings() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a SETTINGS frame with a length other than a multiple of 6 octets",
 		Requirement: "The endpoint MUST respond with a connection error of type FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			_, err := conn.ReadClientPreface()
+			if err != nil {
+				return err
+			}
+
+			_, ok := conn.WaitEventByType(spec.EventSettingsFrame)
+			if !ok {
+				return errors.New("First frame from client must be SETTINGS")
+			}
+
 			// SETTINGS frame:
 			// length: 3, flags: 0x0, stream_id: 0x0
 			conn.Send([]byte("\x00\x00\x03\x04\x00\x00\x00\x00\x00"))

--- a/client/6_7_ping.go
+++ b/client/6_7_ping.go
@@ -16,7 +16,12 @@ func Ping() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a PING frame",
 		Requirement: "The endpoint MUST sends a PING frame with ACK, with an identical payload.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			data := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
 			conn.WritePing(false, data)
 
@@ -32,7 +37,12 @@ func Ping() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a PING frame with ACK",
 		Requirement: "The endpoint MUST NOT respond to PING frames with ACK.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			unexpectedData := [8]byte{'i', 'n', 'v', 'a', 'l', 'i', 'd'}
 			expectedData := [8]byte{'h', '2', 's', 'p', 'e', 'c'}
 			conn.WritePing(true, unexpectedData)
@@ -48,7 +58,12 @@ func Ping() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a PING frame with a stream identifier field value other than 0x0",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// PING frame:
 			// length: 8, flags: 0x0, stream_id: 1
 			conn.Send([]byte("\x00\x00\x08\x06\x00\x00\x00\x00\x01"))
@@ -64,7 +79,12 @@ func Ping() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a PING frame with a length field value other than 8",
 		Requirement: "The endpoint MUST treat this as a connection error of type FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// PING frame:
 			// length: 8, flags: 0x0, stream_id: 1
 			conn.Send([]byte("\x00\x00\x06\x06\x00\x00\x00\x00\x00"))

--- a/client/6_8_goaway.go
+++ b/client/6_8_goaway.go
@@ -16,7 +16,12 @@ func GoAway() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a GOAWAY frame with a stream identifier other than 0x0",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// GOAWAY frame:
 			// length: 8, flags: 0x0, stream_id: 1
 			conn.Send([]byte("\x00\x00\x08\x07\x00\x00\x00\x00\x01"))

--- a/client/6_9_1_the_flow_control_window.go
+++ b/client/6_9_1_the_flow_control_window.go
@@ -22,7 +22,12 @@ func TheFlowControlWindow() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1",
 		Requirement: "The endpoint MUST sends a GOAWAY frame with a FLOW_CONTROL_ERROR code.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteWindowUpdate(0, 2147483647)
 			conn.WriteWindowUpdate(0, 2147483647)
 
@@ -59,7 +64,17 @@ func TheFlowControlWindow() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream",
 		Requirement: "The endpoint MUST sends a RST_STREAM frame with a FLOW_CONTROL_ERROR code.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,

--- a/client/6_9_window_update.go
+++ b/client/6_9_window_update.go
@@ -18,7 +18,12 @@ func WindowUpdate() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a WINDOW_UPDATE frame with a flow control window increment of 0",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			conn.WriteWindowUpdate(0, 0)
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeProtocol)
@@ -33,7 +38,17 @@ func WindowUpdate() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a WINDOW_UPDATE frame with a flow control window increment of 0 on a stream",
 		Requirement: "The endpoint MUST treat this as a connection error of type PROTOCOL_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			req, err := conn.ReadRequest()
+			if err != nil {
+				return err
+			}
+
 			headers := spec.CommonRespHeaders(c)
 			hp := http2.HeadersFrameParam{
 				StreamID:      req.StreamID,
@@ -55,7 +70,12 @@ func WindowUpdate() *spec.ClientTestGroup {
 	tg.AddTestCase(&spec.ClientTestCase{
 		Desc:        "Sends a WINDOW_UPDATE frame with a length other than 4 octets",
 		Requirement: "The endpoint MUST treat this as a connection error of type FRAME_SIZE_ERROR.",
-		Run: func(c *config.Config, conn *spec.Conn, req *spec.Request) error {
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
 			// WINDOW_UPDATE frame:
 			// length: 3, flags: 0x0, stream_id: 0
 			conn.Send([]byte("\x00\x00\x03\x08\x00\x00\x00\x00\x00"))

--- a/spec/connection.go
+++ b/spec/connection.go
@@ -616,15 +616,9 @@ func (conn *Conn) handshakeAsServer() error {
 	done := make(chan error)
 
 	go func() {
-		prefaceBytes, err := conn.readBytes(24)
+		_, err := conn.ReadClientPreface()
 		if err != nil {
 			done <- err
-			return
-		}
-
-		preface := string(prefaceBytes[:])
-		if preface != "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" {
-			done <- errors.New("Illegal preface")
 			return
 		}
 
@@ -659,6 +653,19 @@ func (conn *Conn) handshakeAsServer() error {
 		return ErrTimeout
 	}
 	return nil
+}
+
+func (conn *Conn) ReadClientPreface() (string, error) {
+	prefaceBytes, err := conn.readBytes(24)
+	if err != nil {
+		return "", err
+	}
+
+	preface := string(prefaceBytes[:])
+	if preface != "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" {
+		return "", errors.New("Illegal preface")
+	}
+	return preface, nil
 }
 
 func (conn *Conn) readBytes(size int) ([]byte, error) {

--- a/spec/specd.go
+++ b/spec/specd.go
@@ -146,7 +146,7 @@ type ClientTestCase struct {
 	Requirement string
 	Parent      *ClientTestGroup
 	Result      *ClientTestResult
-	Run         func(c *config.Config, conn *Conn, req *Request) error
+	Run         func(c *config.Config, conn *Conn) error
 
 	Port int
 }


### PR DESCRIPTION
Moved handshaking action into test cases instead of handshaking at start of every connection.
So that we can have some tests sending frame or invalid data before sending server preface.

Refs: [PR-74#comment](https://github.com/summerwind/h2spec/pull/74#issuecomment-282482199)