### PR TITLE
Correct a client test description

### DIFF
--- a/client/5_1_1_stream_identifiers.go
+++ b/client/5_1_1_stream_identifiers.go
@@ -13,7 +13,7 @@ func StreamIdentifiers() *spec.ClientTestGroup {
 	// MUST respond with a connection error (Section 5.4.1) of
 	// type PROTOCOL_ERROR.
 	tg.AddTestCase(&spec.ClientTestCase{
-		Desc:        "Sends even-numbered stream identifier",
+		Desc:        "Sends odd-numbered stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
 		Run: func(c *config.Config, conn *spec.Conn) error {
 			err := conn.Handshake()

--- a/client/5_1_1_stream_identifiers.go
+++ b/client/5_1_1_stream_identifiers.go
@@ -13,7 +13,7 @@ func StreamIdentifiers() *spec.ClientTestGroup {
 	// MUST respond with a connection error (Section 5.4.1) of
 	// type PROTOCOL_ERROR.
 	tg.AddTestCase(&spec.ClientTestCase{
-		Desc:        "Sends odd-numbered stream identifier",
+		Desc:        "Sends an unexpected stream identifier",
 		Requirement: "The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.",
 		Run: func(c *config.Config, conn *spec.Conn) error {
 			err := conn.Handshake()


### PR DESCRIPTION
I initially created the PR doing the change even-numbered -> odd-numbered

But the test is not about that, odd-numbered is expected for the responses. The test is about receiving a HEADERS frame with a stream identifier for a stream that is idle, which cannot occur as far as the client is concerned. The same applies to both even and odd-numbered stream identifiers.