### PR TITLE
wait the server to fill the test result

### DIFF
--- a/spec/server.go
+++ b/spec/server.go
@@ -106,6 +106,7 @@ func (server *Server) handleConn(conn *Conn, tc *ClientTestCase) {
 
 	tc.Result = tr
 	tc.Parent.IncRecursive(tc.Result.Failed, tc.Result.Skipped, 1)
+	tc.Done <- true
 }
 
 func groupNames(tg *ClientTestGroup) string {

--- a/spec/specd.go
+++ b/spec/specd.go
@@ -149,10 +149,12 @@ type ClientTestCase struct {
 	Run         func(c *config.Config, conn *Conn) error
 
 	Port int
+	Done chan bool
 }
 
 // Test runs itself as a test case.
 func (tc *ClientTestCase) Test(c *config.Config) error {
+	tc.Done = make(chan bool)
 	done := make(chan error)
 	go func() {
 		split := strings.Split(c.Exec, " ")
@@ -166,6 +168,7 @@ func (tc *ClientTestCase) Test(c *config.Config) error {
 			cmd.Stderr = os.Stderr
 		}
 		err := cmd.Run()
+		<-tc.Done
 		done <- err
 	}()
 


### PR DESCRIPTION
I found an issue in client test that, when the client process exits before the server sets the result in `handleConn`, the test fails with the following error message even if the test was actually successful.
```
Error: the server didn't receive the request
```
This PR fixes that by waiting the server in client goroutine