### PR TITLE
Have the 6.7/4 test case actually check for length

### DIFF
--- a/http2/6_7_ping.go
+++ b/http2/6_7_ping.go
@@ -86,8 +86,8 @@ func Ping() *spec.TestGroup {
 			}
 
 			// PING frame:
-			// length: 8, flags: 0x0, stream_id: 1
-			conn.Send([]byte("\x00\x00\x06\x06\x00\x00\x00\x00\x01"))
+			// length: 8, flags: 0x0, stream_id: 0
+			conn.Send([]byte("\x00\x00\x06\x06\x00\x00\x00\x00\x00"))
 			conn.Send([]byte("\x00\x00\x00\x00\x00\x00"))
 
 			return spec.VerifyConnectionError(conn, http2.ErrCodeFrameSize)


### PR DESCRIPTION
For implementations that check for the stream id before the payload length, this test case isn't actually checking for what it claims.