### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/reporter/client_reporter.go
+++ b/reporter/client_reporter.go
@@ -23,7 +23,7 @@ func PrintSummaryForClient(group *spec.ClientTestGroup) {
 	log.Println(SummaryForClient(group))
 }
 
-// FailedTests outputs the report of failed tests.
+// PrintFailedClientTests outputs the report of failed tests.
 func PrintFailedClientTests(group *spec.ClientTestGroup) {
 	log.Print("Failures: \n\n")
 

--- a/spec/connection.go
+++ b/spec/connection.go
@@ -301,7 +301,7 @@ func (conn *Conn) WritePing(ack bool, data [8]byte) error {
 	return conn.framer.WritePing(ack, data)
 }
 
-// WritePing sends a PING frame.
+// WriteGoAway sends a PING frame.
 func (conn *Conn) WriteGoAway(maxStreamID uint32, code http2.ErrCode, debugData []byte) error {
 	if conn.Verbose {
 		conn.debugFramer.WriteGoAway(maxStreamID, code, debugData)

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -130,7 +130,7 @@ func (tg *TestGroup) AddTestGroup(stg *TestGroup) {
 	tg.Groups = append(tg.Groups, stg)
 }
 
-// AddTestGroup registers a test to this group.
+// AddTestCase registers a test to this group.
 func (tg *TestGroup) AddTestCase(tc *TestCase) {
 	tc.Parent = tg
 	if tg.Strict {
@@ -203,7 +203,7 @@ type TestError struct {
 	Actual   string
 }
 
-// Returns a string containing the reason of the error.
+// Error returns a string containing the reason of the error.
 func (e TestError) Error() string {
 	return fmt.Sprintf("%s\n%s", strings.Join(e.Expected, "\n"), e.Actual)
 }

--- a/spec/specd.go
+++ b/spec/specd.go
@@ -93,13 +93,13 @@ func (tg *ClientTestGroup) Test(c *config.Config) {
 	log.PrintBlankLine()
 }
 
-// AddClientTestGroup registers a group to this group.
+// AddTestGroup registers a group to this group.
 func (tg *ClientTestGroup) AddTestGroup(stg *ClientTestGroup) {
 	stg.Parent = tg
 	tg.Groups = append(tg.Groups, stg)
 }
 
-// AddClientTestGroup registers a test to this group.
+// AddTestCase registers a test to this group.
 func (tg *ClientTestGroup) AddTestCase(tc *ClientTestCase) {
 	tc.Parent = tg
 	tc.Seq = len(tg.Tests) + 1

--- a/spec/util.go
+++ b/spec/util.go
@@ -76,7 +76,7 @@ func CommonHeaders(c *config.Config) []hpack.HeaderField {
 	}
 }
 
-// CommonHeaders returns a array of header field of HPACK contained
+// CommonRespHeaders returns a array of header field of HPACK contained
 // common http headers used in various test case.
 func CommonRespHeaders(c *config.Config) []hpack.HeaderField {
 	return []hpack.HeaderField{


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?