### PR TITLE
Literal Header Field representation with invalid index

### DIFF
--- a/hpack/2_3_3_index_address_space.go
+++ b/hpack/2_3_3_index_address_space.go
@@ -12,7 +12,7 @@ func IndexAddressSpace() *spec.TestGroup {
 	// Indices strictly greater than the sum of the lengths of both
 	// tables MUST be treated as a decoding error.
 	tg.AddTestCase(&spec.TestCase{
-		Desc:        "Sends a header field representation with invalid index",
+		Desc:        "Sends a indexed header field representation with invalid index",
 		Requirement: "The endpoint MUST treat this as a decoding error.",
 		Run: func(c *config.Config, conn *spec.Conn) error {
 			var streamID uint32 = 1
@@ -24,6 +24,38 @@ func IndexAddressSpace() *spec.TestGroup {
 
 			// Indexed header field representation with index 70
 			indexedRep := []byte("\xC6")
+
+			headers := spec.CommonHeaders(c)
+			blockFragment := conn.EncodeHeaders(headers)
+			blockFragment = append(blockFragment, indexedRep...)
+
+			hp := http2.HeadersFrameParam{
+				StreamID:      streamID,
+				EndStream:     true,
+				EndHeaders:    true,
+				BlockFragment: blockFragment,
+			}
+			conn.WriteHeaders(hp)
+
+			return spec.VerifyConnectionError(conn, http2.ErrCodeCompression)
+		},
+	})
+
+	// Indices strictly greater than the sum of the lengths of both
+	// tables MUST be treated as a decoding error.
+	tg.AddTestCase(&spec.TestCase{
+		Desc:        "Sends a literal header field representation with invalid index",
+		Requirement: "The endpoint MUST treat this as a decoding error.",
+		Run: func(c *config.Config, conn *spec.Conn) error {
+			var streamID uint32 = 1
+
+			err := conn.Handshake()
+			if err != nil {
+				return err
+			}
+
+			// Literal Header Field with Incremental Indexing (index=70 & value=empty)
+			indexedRep := []byte("\x7F\x07\x00")
 
 			headers := spec.CommonHeaders(c)
 			blockFragment := conn.EncodeHeaders(headers)


### PR DESCRIPTION
The current hpack/2.3.3 test covers an invalid index on the "Indexed Header Field". This adds the case of an invalid index on the "Literal Header Field with Incremental Indexing". 

We recently found a bug with this case on our project ( https://github.com/apache/trafficserver/pull/6786 ). It'd be great if h2spec covers this case.