### PR TITLE
Validate only the length of the DATA frame in 6.9.2/1

### DIFF
--- a/http2/6_9_2_initial_flow_control_window_size.go
+++ b/http2/6_9_2_initial_flow_control_window_size.go
@@ -72,11 +72,6 @@ func InitialFlowControlWindowSize() *spec.TestGroup {
 			}
 			conn.WriteSettings(settings2...)
 
-			err = spec.VerifySettingsFrameWithAck(conn)
-			if err != nil {
-				return err
-			}
-
 			// Wait for DATA frame...
 			actual, passed := conn.WaitEventByType(spec.EventDataFrame)
 			switch event := actual.(type) {


### PR DESCRIPTION
This PR fixes the race condition reported in #115.