### PR TITLE
Check for connection reset correctly

### DIFF
--- a/spec/connection.go
+++ b/spec/connection.go
@@ -371,15 +371,15 @@ func (conn *Conn) WaitEvent() Event {
 
 		opErr, ok := err.(*net.OpError)
 		if ok {
-			if opErr.Err == syscall.ECONNRESET {
-				ev = ConnectionClosedEvent{}
-				conn.vlog(ev, false)
-				return ev
-			}
+			scErr, ok := opErr.Err.(*os.SyscallError)
+			if ok {
+				if scErr.Err == syscall.ECONNRESET {
+					ev = ConnectionClosedEvent{}
+					conn.vlog(ev, false)
+					return ev
+				}
 
-			if runtime.GOOS == "windows" {
-				scErr, ok := opErr.Err.(*os.SyscallError)
-				if ok {
+				if runtime.GOOS == "windows" {
 					const WSAECONNABORTED = 10053
 					const WSAECONNRESET = 10054
 

--- a/spec/connection_test.go
+++ b/spec/connection_test.go
@@ -1,0 +1,53 @@
+package spec
+
+import (
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/summerwind/h2spec/config"
+)
+
+// TestConnWaitEvent verifies the ConnectionClosedEvent
+func TestConnWaitEvent(t *testing.T) {
+	srv, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Errorf("Failed to start server: %v", err)
+	}
+	srvAddr, err := net.ResolveTCPAddr("tcp", srv.Addr().String())
+	if err != nil {
+		t.Errorf("Failed to get server port: %v", err)
+	}
+
+	// Accept client but disconnect immediately
+	go func() {
+		conn, err := srv.Accept()
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		// Force a RST when closing
+		tcpConn := conn.(*net.TCPConn)
+		tcpConn.SetLinger(0)
+
+		conn.Close()
+	}()
+
+	config := config.Config{
+		Port:    srvAddr.Port,
+		Timeout: 2 * time.Second,
+		TLS:     false,
+	}
+
+	conn, err := Dial(&config)
+	if err != nil {
+		t.Errorf("Failed to Dial: %v", err)
+	}
+
+	ev := conn.WaitEvent()
+	if _, ok := ev.(ConnectionClosedEvent); !ok {
+		t.Errorf("Expected Connection closed event but got '%v'", ev)
+	}
+}


### PR DESCRIPTION
During ninenines/gun#241 I got an intermittent fault, that after a lot of tests boiled down to this correction.
It was usually test 6.5.1 that failed, and `connection reset by peer` was involved.

The type net.OpError actually embeds the type os.SyscallError, which holds the ECONNRESET.

I also added a test to trigger the fault, and to verify the remedy. (verified using GithubActions both on ubuntu and windows)
The test uses real tcp sockets to get an exact behavior in this case, but using real sockets in tests might make people scream, so its optional and can be removed if wanted.
Thanks!