### PR TITLE
[junit] Fix JUnit generated XML report.

### DIFF
--- a/reporter/junit_report.go
+++ b/reporter/junit_report.go
@@ -33,7 +33,7 @@ type JUnitTestSuite struct {
 type JUnitTestCase struct {
 	XMLName   xml.Name      `xml:"testcase"`
 	Package   string        `xml:"package,attr"`
-	ClassName string        `xml:"classname,attr"`
+	Name      string        `xml:"name,attr"`
 	Time      string        `xml:"time,attr"`
 	Failure   *JUnitFailure `xml:"failure"`
 	Skipped   *JUnitSkipped `xml:"skipped"`
@@ -102,7 +102,7 @@ func convertJUnitReport(groups []*spec.TestGroup) []*JUnitTestSuite {
 
 			jtc := &JUnitTestCase{
 				Package:   tg.ID(),
-				ClassName: tc.Desc,
+				Name:      tc.Desc,
 				Time:      fmt.Sprintf("%.04f", tc.Result.Duration.Seconds()),
 			}
 


### PR DESCRIPTION
Based on the Maven surefire-plugin JUnit XSD schema [1], `name`
attribute in `testcase` is required. Let's use description value
that is currently used as `classname` attribute for this purpose.

This issue may lead to errors with JUnit plugin 1.32 for Jenkins.

[1] https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd