### PR TITLE
add manual tests exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Usage:
 Flags:
   -c, --ciphers string          List of colon-separated TLS cipher names
       --dryrun                  Display only the title of test cases
+  -x, --exclude strings         Disable specific tests
       --help                    Display this help and exit
   -h, --host string             Target host (default "127.0.0.1")
   -k, --insecure                Don't verify server's certificate
@@ -84,6 +85,12 @@ When *Strict Mode* is enabled, h2spec will run the test cases related to the con
 
 ```
 $ h2spec --strict
+```
+
+### Disable Certain Tests
+If you use `h2spec` as a part of your CI/CD pipeline, you may find it useful to be able to manually exclude specific tests by their *Spec ID*s before the corresponding issue gets resolved:
+```
+$ h2spec --exclude hpack/2 --exclude hpack/4/1
 ```
 
 ## Screenshot

--- a/cmd/h2spec/h2spec.go
+++ b/cmd/h2spec/h2spec.go
@@ -41,6 +41,7 @@ func main() {
 	flags.BoolP("verbose", "v", false, "Output verbose log")
 	flags.Bool("version", false, "Display version information and exit")
 	flags.Bool("help", false, "Display this help and exit")
+	flags.StringSliceP("exclude", "x", []string{}, "Disable specific tests")
 
 	err := cmd.Execute()
 	if err != nil {
@@ -122,6 +123,11 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	exclude, err := flags.GetStringSlice("exclude")
+	if err != nil {
+		return err
+	}
+
 	if port == 0 {
 		if tls {
 			port = 443
@@ -144,6 +150,7 @@ func run(cmd *cobra.Command, args []string) error {
 		Insecure:     insecure,
 		Verbose:      verbose,
 		Sections:     args,
+		Excluded:     exclude,
 	}
 
 	success, err := h2spec.Run(c)

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	CertKeyFile  string
 	Exec         string
 	FromPort     int
+	Excluded     []string
 }
 
 // Addr returns the string concatenated with hostname and port number.


### PR DESCRIPTION
Now you can disable certain tests by passing `-x/--exclude` flags,
specifying particular *Spec ID*s. Multiple values are allowed.