### PR TITLE
support darwin/linux arm64 release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,21 @@ release:
 	GOARCH=amd64 GOOS=darwin go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
 	tar -czf release/h2spec_darwin_amd64.tar.gz h2spec
 	rm -rf h2spec
-	
+
+	GOARCH=arm64 GOOS=darwin go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
+	tar -czf release/h2spec_darwin_arm64.tar.gz h2spec
+	rm -rf h2spec
+
 	GOARCH=amd64 GOOS=windows go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
 	zip release/h2spec_windows_amd64.zip -r h2spec.exe
 	rm -rf h2spec.exe
 	
 	GOARCH=amd64 GOOS=linux go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
 	tar -czf release/h2spec_linux_amd64.tar.gz h2spec
+	rm -rf h2spec
+
+	GOARCH=arm64 GOOS=linux go build $(BUILD_FLAGS) cmd/h2spec/h2spec.go
+	tar -czf release/h2spec_linux_arm64.tar.gz h2spec
 	rm -rf h2spec
 
 github-release: release


### PR DESCRIPTION
## Motivation

h2spec doesn't support arm64 release binary in [any releases](https://github.com/summerwind/h2spec/releases).

## Do

Build darwin/linux arm64 binaries in `make release`.

```sh
> uname -a
Darwin MacBook-Pro 22.5.0 Darwin Kernel Version 22.5.0: Thu Jun  8 22:22:19 PDT 2023; root:xnu-8796.121.3~7/RELEASE_ARM64_T8103 x86_64
> make release
> tar xvzf release/h2spec_darwin_arm64.tar.gz
x h2spec
>  ./h2spec --help
Conformance testing tool for HTTP/2 implementation.

Usage:
  h2spec [spec...] [flags]

Flags:
  -c, --ciphers string          List of colon-separated TLS cipher names
      --dryrun                  Display only the title of test cases
      --help                    Display this help and exit
  -h, --host string             Target host (default "127.0.0.1")
  -k, --insecure                Don't verify server's certificate
  -j, --junit-report string     Path for JUnit test report
      --max-header-length int   Maximum length of HTTP header (default 4000)
  -P, --path string             Target path (default "/")
  -p, --port int                Target port
  -S, --strict                  Run all test cases including strict test cases
  -o, --timeout int             Time seconds to test timeout (default 2)
  -t, --tls                     Connect over TLS
  -v, --verbose                 Output verbose log
      --version                 Display version information and exit
```