### PR TITLE
Changed test 6.9.1.3 to a POST

### DIFF
--- a/http2/6_9_1_the_flow_control_window.go
+++ b/http2/6_9_1_the_flow_control_window.go
@@ -145,9 +145,11 @@ func TheFlowControlWindow() *spec.TestGroup {
 			}
 
 			headers := spec.CommonHeaders(c)
+			headers[0].Value = "POST"
+
 			hp := http2.HeadersFrameParam{
 				StreamID:      streamID,
-				EndStream:     false,
+				EndStream:     true,
 				EndHeaders:    true,
 				BlockFragment: conn.EncodeHeaders(headers),
 			}
@@ -155,6 +157,8 @@ func TheFlowControlWindow() *spec.TestGroup {
 
 			conn.WriteWindowUpdate(streamID, 2147483647)
 			conn.WriteWindowUpdate(streamID, 2147483647)
+
+			conn.WriteData(streamID, true, []byte("test"))
 
 			actual, passed := conn.WaitEventByType(spec.EventRSTStreamFrame)
 			switch event := actual.(type) {


### PR DESCRIPTION
While testing h2spec 2.6.0 I ran into an error were the server would respond before it received the `WINDOW_UPDATE` frames.

Before the change:
```
07:12:45 zeus:((v2.6.0))~/dev/h2spec$ ./h2spec -vkt -p 4443 -P /cache/1024 http2/6.9.1/3
Hypertext Transfer Protocol Version 2 (HTTP/2)
  6. Frame Definitions
    6.9. WINDOW_UPDATE
      6.9.1. The Flow-Control Window
             [send] SETTINGS Frame (length:6, flags:0x00, stream_id:0)
             [recv] SETTINGS Frame (length:18, flags:0x00, stream_id:0)
             [send] SETTINGS Frame (length:0, flags:0x01, stream_id:0)
             [recv] SETTINGS Frame (length:0, flags:0x01, stream_id:0)
             [send] HEADERS Frame (length:24, flags:0x04, stream_id:1)
             [send] WINDOW_UPDATE Frame (length:4, flags:0x00, stream_id:1)
             [send] WINDOW_UPDATE Frame (length:4, flags:0x00, stream_id:1)
             [recv] HEADERS Frame (length:148, flags:0x04, stream_id:1)
             [recv] DATA Frame (length:1024, flags:0x01, stream_id:1)
             [recv] Timeout
        using source address 127.0.0.1:53226
        × 3: Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream
          -> The endpoint MUST sends a RST_STREAM frame with a FLOW_CONTROL_ERROR code.
             Expected: RST_STREAM Frame (Error Code: FLOW_CONTROL_ERROR)
               Actual: DATA Frame (length:1024, flags:0x01, stream_id:1)

Failures:

Hypertext Transfer Protocol Version 2 (HTTP/2)
  6. Frame Definitions
    6.9. WINDOW_UPDATE
      6.9.1. The Flow-Control Window
        using source address 127.0.0.1:53226
        × 3: Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream
          -> The endpoint MUST sends a RST_STREAM frame with a FLOW_CONTROL_ERROR code.
             Expected: RST_STREAM Frame (Error Code: FLOW_CONTROL_ERROR)
               Actual: DATA Frame (length:1024, flags:0x01, stream_id:1)

Finished in 2.0084 seconds
1 tests, 0 passed, 0 skipped, 1 failed
```

After the change:
```
07:11:31 zeus:(fix_6_9_1_3)~/dev/h2spec$ ./h2spec -vkt -p 4443 -P /cache/1024 http2/6.9.1/3
Hypertext Transfer Protocol Version 2 (HTTP/2)
  6. Frame Definitions
    6.9. WINDOW_UPDATE
      6.9.1. The Flow-Control Window
             source address: 127.0.0.1:45728
             [send] SETTINGS Frame (length:6, flags:0x00, stream_id:0)
             [recv] SETTINGS Frame (length:18, flags:0x00, stream_id:0)
             [send] SETTINGS Frame (length:0, flags:0x01, stream_id:0)
             [recv] SETTINGS Frame (length:0, flags:0x01, stream_id:0)
             [send] HEADERS Frame (length:24, flags:0x05, stream_id:1)
             [send] WINDOW_UPDATE Frame (length:4, flags:0x00, stream_id:1)
             [send] WINDOW_UPDATE Frame (length:4, flags:0x00, stream_id:1)
             [send] DATA Frame (length:4, flags:0x01, stream_id:1)
             [recv] RST_STREAM Frame (length:4, flags:0x00, stream_id:1)
        ✔ 3: Sends multiple WINDOW_UPDATE frames increasing the flow control window to above 2^31-1 on a stream

Finished in 0.0053 seconds
1 tests, 1 passed, 0 skipped, 0 failed
```